### PR TITLE
Add dioxus-material-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A collection of awesome things regarding the Dioxus ecosystem.
 - [dioxus-helmet](https://github.com/saicu/dioxus-helmet) : Place elements in the `<head></head>` of your document.
 - [dioxus-layout](https://gitlab.com/MAlrusayni/dioxus-layout) : Layouts components for Dioxus
 - [dioxus-free-icons](https://github.com/nissy-dev/dioxus-free-icons) : Free icon components for Dioxus
+- [dioxus-material-icons](https://github.com/lennartkloock/dioxus-material-icons) : Material Icons for Dioxus
 
 ## Network
 


### PR DESCRIPTION
I made the `dioxus-material-icons` crate to render Google's material design icons with a simple but configurable component.
Would love to see it here :)

It's an alternative to `dioxus-free-icons` which takes another render approach.