### PR TITLE
Remove unnecessary Cargo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/target
-Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "awesome-dioxus"
-version = "0.1.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
I assume these were accidentally included with `cargo new`. They give off the idea that this is repo is a crate, when in reality it simply stores `awesome.json`.