### PR TITLE
add biyard website using dioxus 0.6.0-alpha.2

### DIFF
--- a/awesome.json
+++ b/awesome.json
@@ -464,5 +464,16 @@
             "repo": "sqlite-repr"
         },
         "link": "https://torymur.github.io/sqlite-repr/"
+    },
+    {
+        "name": "Biyard Website",
+        "description": "Company website utilizes dioxus 0.6.0-alpha.2 and AWS serverless services with CI/CD",
+        "type": "MadeWith",
+        "category": "App",
+        "github": {
+            "username": "biyard",
+            "repo": "homepage"
+        },
+        "link": "https://biyard.co"
     }
 ]


### PR DESCRIPTION
* Add a good example using dioxus 0.6.0-alpha.2.
* It shows how to setup CI/CD for AWS serverless services.