### PR TITLE
Updated URL for dioxus-oauth

### DIFF
--- a/awesome.json
+++ b/awesome.json
@@ -540,7 +540,7 @@
             "username": "biyard",
             "repo": "dioxus-oauth"
         },
-        "link": "https://github.com/biyard/democrasee/tree/main/packages/dioxus-oauth"
+        "link": "https://github.com/biyard/rust-sdk/tree/main/packages/dioxus-oauth"
     },
     {
         "name": "Biyard Website",

--- a/awesome.json
+++ b/awesome.json
@@ -538,7 +538,7 @@
         "category": "Util",
         "github": {
             "username": "biyard",
-            "repo": "dioxus-oauth"
+            "repo": "rust-sdk"
         },
         "link": "https://github.com/biyard/rust-sdk/tree/main/packages/dioxus-oauth"
     },


### PR DESCRIPTION
I updated the `dioxus-oauth` URL after finding that the current value (https://github.com/biyard/democrasee/tree/main/packages/dioxus-oauth) results in a 404 from GitHub. Clicking from there to the org its listed under (https://github.com/biyard) shows `dioxus-oath` as the top repository, but then the README there says the project is now located at https://github.com/biyard/rust-sdk/tree/main/packages/dioxus-oauth.