### PR TITLE
Add FlowFlow — voice notes iOS app with RAG chat

### DIFF
--- a/awesome.json
+++ b/awesome.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "FlowFlow",
+        "description": "100% Rust voice notes app for iOS with speech-to-text, RAG chat, auto-tagging, and document import (PDF/DOCX). Built with Dioxus 0.7, LanceDB, SQLite, and rig-core.",
+        "type": "MadeWith",
+        "category": "App",
+        "github": {
+            "username": "mirkobozzetto",
+            "repo": "flowflow"
+        },
+        "link": null
+    },
+    {
         "name": "Xmes",
         "description": "Xmes is an open-source decentralized messenger built on XMTP. No app store, no signup, no central server, no phone number.",
         "type": "MadeWith",


### PR DESCRIPTION
Most of my ideas come when I'm walking or between two tasks — and they vanish just as fast.

So I built **FlowFlow**, a voice notes app for iPhone, entirely in Rust with Dioxus. 
You talk, it transcribes (via Soniox), and later the chat finds your notes when you need them.

The part I like most: no manual searching. I ask "what was that pricing idea?" and the right passages come up with links to the original notes. That's RAG powered by rig-core and LanceDB, running locally on the device.

It also auto-tags notes, imports PDF/DOCX documents into the knowledge base, and supports both OpenAI and Anthropic as LLM providers.

SQLite + RIG + LanceDB & Tailwind CSS V4 — all Rust, zero JS.

Repo: [mirkobozzetto/flowflow](https://github.com/mirkobozzetto/flowflow)