### PR TITLE
Add OxDM, the ONVIF IP camera manager

### DIFF
--- a/awesome.json
+++ b/awesome.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "OxDM",
+        "description": "A cross-platform desktop ONVIF IP camera manager — discovery, live video (MJPEG/RTSP), PTZ, imaging, events, and an ONVIF health check.",
+        "type": "MadeWith",
+        "category": "App",
+        "github": {
+            "username": "smiti1642",
+            "repo": "oxdm"
+        },
+        "link": "https://github.com/smiti1642/oxdm"
+    },
+    {
         "name": "Dioxus UI",
         "description": "Open-source component library for Dioxus, built with Rust.",
         "type": "Awesome",
@@ -684,16 +695,5 @@
             "repo": "supa-dioxus"
         },
         "link": "https://github.com/SuddenlyHazel/supa-dioxus"
-    },
-    {
-        "name": "OxDM",
-        "description": "A cross-platform desktop ONVIF IP camera manager — discovery, live video (MJPEG/RTSP), PTZ, imaging, events, and an ONVIF health check.",
-        "type": "MadeWith",
-        "category": "App",
-        "github": {
-            "username": "smiti1642",
-            "repo": "oxdm"
-        },
-        "link": "https://github.com/smiti1642/oxdm"
     }
 ]

--- a/awesome.json
+++ b/awesome.json
@@ -8,7 +8,7 @@
             "username": "smiti1642",
             "repo": "oxdm"
         },
-        "link": "https://github.com/smiti1642/oxdm"
+        "link": null
     },
     {
         "name": "Dioxus UI",

--- a/awesome.json
+++ b/awesome.json
@@ -684,5 +684,16 @@
             "repo": "supa-dioxus"
         },
         "link": "https://github.com/SuddenlyHazel/supa-dioxus"
+    },
+    {
+        "name": "OxDM",
+        "description": "A cross-platform desktop ONVIF IP camera manager — discovery, live video (MJPEG/RTSP), PTZ, imaging, events, and an ONVIF health check.",
+        "type": "MadeWith",
+        "category": "App",
+        "github": {
+            "username": "smiti1642",
+            "repo": "oxdm"
+        },
+        "link": "https://github.com/smiti1642/oxdm"
     }
 ]


### PR DESCRIPTION
Adds [OxDM](https://crates.io/crates/oxvif-device-manager), a cross-platform desktop ONVIF IP camera manager built with Dioxus.

The ONVIF protocol layer is a separate crate I wrote from scratch ([oxvif](https://crates.io/crates/oxvif)); OxDM is the GUI built on top of it.

Features: device discovery, live video (MJPEG/RTSP), PTZ, imaging/media config,PullPoint events, and a health check.

Author here. Repo: https://github.com/smiti1642/oxdm